### PR TITLE
improve input handling with number input fields

### DIFF
--- a/components/cost_limits.tsx
+++ b/components/cost_limits.tsx
@@ -4,6 +4,7 @@ import {
   saveCostLimits,
   setAndSaveStateWrapper,
 } from '@/engine/cookie';
+import { disallowNonDigits } from '@/engine/input_validation';
 
 export type EffectiveCostLimitsType = {
   witchPoints: number;
@@ -125,18 +126,34 @@ const CostLimits = ({
       <input
         id="witchpoints"
         disabled={!editable || costLimit.unlimited}
-        type="text"
+        type={costLimit.unlimited ? 'text' : 'number'}
+        min="0"
+        step="100"
         value={costLimit.unlimited ? '\u221E' : costLimit.witchPoints}
+        onBeforeInput={disallowNonDigits}
         onChange={e => setWitchPointLimit(e.target.value)}
+        onBlur={e => {
+          if (e.target.value == '') {
+            setWitchPointLimit('0');
+          }
+        }}
       />
       <br />
       Max. Diamonds:{' '}
       <input
         id="diamonds"
         disabled={!editable || costLimit.unlimited}
-        type="text"
+        type={costLimit.unlimited ? 'text' : 'number'}
+        min="0"
+        step="25"
         value={costLimit.unlimited ? '\u221E' : costLimit.diamonds}
+        onBeforeInput={disallowNonDigits}
         onChange={e => setDiamondLimit(e.target.value)}
+        onBlur={e => {
+          if (e.target.value == '') {
+            setDiamondLimit('0');
+          }
+        }}
       />
     </div>
   );

--- a/components/diplomas.tsx
+++ b/components/diplomas.tsx
@@ -1,4 +1,11 @@
+import { useState, useEffect } from 'react';
 import { saveDiplomas } from '@/engine/cookie';
+import {
+  getParseIntegerWithDefault,
+  parseAndSetValues,
+  isEquivalentWithDefault,
+  disallowNonDigits,
+} from '@/engine/input_validation';
 
 type DiplomasProps = {
   editable: boolean;
@@ -7,14 +14,25 @@ type DiplomasProps = {
 };
 
 const Diplomas = ({ editable, diplomas, setDiplomas }: DiplomasProps) => {
-  const verifyAndSetDiplomas = (dipl_str: string) => {
-    if (!/^\d+$/.test(dipl_str)) return;
-    const dipl = parseInt(dipl_str);
-    if (dipl > 20) return;
-    if (dipl < 1) return;
+  const [internalDiplomas, setInternalDiplomas] = useState<string>(
+    diplomas.toString()
+  );
+  const setAndSaveDiplomas = (dipl: number) => {
     setDiplomas(dipl);
     saveDiplomas(dipl);
   };
+
+  const isValidNumberOfDiplomas = (dipl: number) => {
+    if (dipl > 20) return false;
+    if (dipl < 1) return false;
+    return true;
+  };
+
+  useEffect(() => {
+    if (!isEquivalentWithDefault(diplomas, internalDiplomas, 1)) {
+      setInternalDiplomas(diplomas.toString());
+    }
+  }, [diplomas]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div>
@@ -26,8 +44,22 @@ const Diplomas = ({ editable, diplomas, setDiplomas }: DiplomasProps) => {
         type="number"
         min="1"
         max="20"
-        value={diplomas}
-        onChange={e => verifyAndSetDiplomas(e.target.value)}
+        value={internalDiplomas}
+        onBeforeInput={disallowNonDigits}
+        onChange={e =>
+          parseAndSetValues(
+            e.target.value,
+            getParseIntegerWithDefault(1),
+            isValidNumberOfDiplomas,
+            setInternalDiplomas,
+            setAndSaveDiplomas
+          )
+        }
+        onBlur={e => {
+          if (e.target.value == '') {
+            setInternalDiplomas('1');
+          }
+        }}
       />
     </div>
   );

--- a/engine/input_validation.ts
+++ b/engine/input_validation.ts
@@ -1,0 +1,77 @@
+import { Dispatch, SetStateAction, CompositionEvent } from 'react';
+
+type ParseResult = {
+  valid: boolean;
+  asString: string;
+  asNumber: number;
+};
+
+const parseIntegerWithDefault = (
+  inputString: string,
+  defaultInterpretation: number
+): ParseResult => {
+  if (inputString == '') {
+    return {
+      valid: true,
+      asString: inputString,
+      asNumber: defaultInterpretation,
+    };
+  }
+  if (!/^\d+$/.test(inputString)) {
+    return {
+      valid: false,
+      asString: '',
+      asNumber: defaultInterpretation,
+    };
+  }
+  return {
+    valid: true,
+    asString: inputString,
+    asNumber: parseInt(inputString),
+  };
+};
+
+export const parseInteger = (inputString: string): ParseResult => {
+  return parseIntegerWithDefault(inputString, 0);
+};
+
+export const getParseIntegerWithDefault = (defaultInterpretation: number) => {
+  const parseIntegerWithGivenDefault = (inputString: string): ParseResult => {
+    return parseIntegerWithDefault(inputString, defaultInterpretation);
+  };
+  return parseIntegerWithGivenDefault;
+};
+
+export const parseAndSetValues = (
+  newValue: string,
+  parseFunc: (input: string) => ParseResult,
+  validationFunc: (newValue: number) => boolean,
+  setInternalValueFunc: Dispatch<SetStateAction<string>>,
+  setExternalValueFunc: (newValue: number) => void
+) => {
+  const { valid, asString, asNumber } = parseFunc(newValue);
+  if (!valid) return;
+  if (!validationFunc(asNumber)) return;
+  setInternalValueFunc(asString);
+  setExternalValueFunc(asNumber);
+};
+
+export const isEquivalentWithDefault = (
+  asNumber: number,
+  asString: string,
+  defaultInterpretation: number
+) => {
+  if (asNumber.toString() == asString) return true;
+  if (asNumber == defaultInterpretation && asString == '') return true;
+  return false;
+};
+
+export const isEquivalent = (asNumber: number, asString: string) => {
+  return isEquivalentWithDefault(asNumber, asString, 0);
+};
+
+export const disallowNonDigits = (e: CompositionEvent<HTMLInputElement>) => {
+  if (!/^\d+$/.test(e.data)) {
+    e.preventDefault();
+  }
+};


### PR DESCRIPTION
Number input fields no longer allow to enter decimal separators or other non-digit numbers (like 3e-6).
Empty strings are allowed and internally interpreted as a default number (zero in most cases). When leaving focus of an input element, an empty string is automatically replaced by the default value.